### PR TITLE
feat: simple transform utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ This library is primarily being used for development for the descriptive thrust 
 
 ## Design
 
+### Simple
+
+We provide a simple translation layer between job specifications. We take the assumption that although each manager has many options, the actual options a user would use is a much smaller set, and it's relatively straight forward to translate (and have better accuracy).
+
+See [examples/transform](examples/transform) for an example.
+
+### Complex
+
 We want to:
 
 1. Generate software graphs for some cluster (fluxion JGF) (this is done with [compspec](https://github.com/compspec/compspec)

--- a/examples/fractale/README.md
+++ b/examples/fractale/README.md
@@ -174,3 +174,8 @@ Saving to "./examples/fractale/cluster-a-containment.png"
 ```
 
 <img src="./cluster-a-containment.svg">
+
+
+## Transform
+
+This mirrors the previous transform functionality for the jobspec library. It's a simple conversion, and no LLMs needed.

--- a/examples/transform/flux-to-kubernetes/README.md
+++ b/examples/transform/flux-to-kubernetes/README.md
@@ -1,0 +1,50 @@
+# Transform
+
+This is an example of doing a transformation between types. We do a simple mapping of parameters.
+To start testing, we will assume one node runs, and of the equivalent container. This way we can create a Job in Kubernetes without considering MPI networking.
+
+```bash
+# Print pretty
+fractale transform --to kubernetes --from flux ./flux_batch.sh --pretty
+
+# Print as raw yaml (to pipe to file)
+fractale transform --to kubernetes --from flux ./flux_batch.sh
+```
+```console
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: lammps
+spec:
+  activeDeadlineSeconds: 100
+  backoffLimit: 4
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        job-name: lammps
+    spec:
+      apiVersion: batch/v1
+      kind: Job
+      metadata:
+        name: lammps
+      spec:
+        backoffLimit: 0
+        template:
+          spec:
+            containers:
+            - args:
+              - lmp -v x 8 -v y 8 -v z 8 -in in.reaxc.hns -nocite
+              command:
+              - /bin/bash
+              - -c
+              image: ghcr.io/converged-computing/lammps-reax:ubuntu22.04
+              name: lammps
+              resources:
+                limits:
+                  cpu: '64'
+                requests:
+                  cpu: '64'
+            restartPolicy: Never
+```

--- a/examples/transform/flux-to-kubernetes/flux-batch.sh
+++ b/examples/transform/flux-to-kubernetes/flux-batch.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#FLUX: -N 1
+#FLUX: -n 64
+#FLUX: -t 100s
+#FLUX: -o cpu-affinity=per-task
+#FLUX: --queue=pbatch
+#FLUX: --setattr=container_image=ghcr.io/converged-computing/lammps-reax:ubuntu22.04
+#FLUX: --output=job.{id}.out
+#FLUX: --error=job.{id}.err
+#FLUX: --job-name=lammps
+
+lmp -v x 8 -v y 8 -v z 8 -in in.reaxc.hns -nocite

--- a/fractale/cli/__init__.py
+++ b/fractale/cli/__init__.py
@@ -71,6 +71,29 @@ def get_parser():
     )
     generate.add_argument("-c", "--cluster", help="cluster name")
 
+    # Transform jobspecs from flux to Kubernetes (starting specific)
+    transform = subparsers.add_parser(
+        "transform",
+        formatter_class=argparse.RawTextHelpFormatter,
+        description="transform a jobspec",
+    )
+    transform.add_argument(
+        "-t",
+        "--to",
+        dest="to_transformer",
+        help="transform into this jobspec",
+        default="kubernetes",
+    )
+    transform.add_argument(
+        "-f", "--from", dest="from_transformer", help="transform from this jobspec", default="flux"
+    )
+    transform.add_argument(
+        "--pretty",
+        help="pretty print in the terminal",
+        default=False,
+        action="store_true",
+    )
+
     # run.add_argument("-t", "--transform", help="transformer to use", default="flux")
     save = subparsers.add_parser(
         "save",
@@ -101,7 +124,7 @@ def get_parser():
     script.add_argument(
         "--transformer", help="transformer to use", default="flux", choices=["flux"]
     )
-    for cmd in [satisfy, script]:
+    for cmd in [satisfy, script, transform]:
         cmd.add_argument("jobspec", help="jobspec yaml or json file")
 
     for cmd in [satisfy, save, script]:
@@ -166,6 +189,8 @@ def run_fractale():
         from .script import main
     elif args.command == "save":
         from .save import main
+    elif args.command == "transform":
+        from .transform import main
     else:
         help(1)
     global registry

--- a/fractale/cli/script.py
+++ b/fractale/cli/script.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import json
+import sys
+
+from rich import print, print_json
+from rich.json import JSON
+from rich.pretty import pprint
+
+from fractale.store import FractaleStore
+from fractale.subsystem import get_subsystem_solver
+from fractale.transformer import get_transformer
+
+
+def main(args, extra, **kwargs):
+    """
+    Save a cluster and subsystem graph.
+    """
+    store = FractaleStore(args.config_dir)
+
+    # Prepare selector and transformer
+    solver = get_subsystem_solver(store.clusters_root, args.solver)
+    # This is probably overloaded, but we need to be able to look up
+    # the templating logic for a subsystem
+    transformer = get_transformer(args.transformer, args.selector, solver)
+    matches = solver.satisfied(args.jobspec, return_results=True)
+    if matches.count == 0:
+        sys.exit(-1)
+
+    # Select the results to generate. This consolidates matches (which might include different nodes)
+    # into clusters and groups of subsystems
+    for script in transformer.render(matches, args.jobspec):
+        # Generate batch script or jobspec and print
+        pprint(script)

--- a/fractale/cli/transform.py
+++ b/fractale/cli/transform.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import os
+import sys
+
+import yaml
+from rich.pretty import pprint
+
+from fractale.transformer import get_transformer
+
+
+def main(args, extra, **kwargs):
+    """
+    Transform between jobspecs.
+    """
+    # The jobspec needs to exist as a file here
+    if not os.path.exists(args.jobspec):
+        sys.exit(f"JobSpec {args.jobspec} does not exist.")
+
+    # No selector or solver, just manual transform
+    from_transformer = get_transformer(args.from_transformer)
+    to_transformer = get_transformer(args.to_transformer)
+
+    # Parse the jobspec to transform from
+    normalized_jobspec = from_transformer.parse(args.jobspec)
+    final_jobspec = to_transformer.convert(normalized_jobspec)
+
+    if args.pretty:
+        pprint(final_jobspec, indent_guides=True)
+    elif args.to_transformer in ["kubernetes"]:
+        yaml.dump(final_jobspec, sys.stdout, sort_keys=True, default_flow_style=False)
+    else:
+        print(final_jobspec)

--- a/fractale/transformer/__init__.py
+++ b/fractale/transformer/__init__.py
@@ -1,11 +1,13 @@
 from .flux import Transformer as FluxTransformer
+from .kubernetes import Transformer as KubernetesTransformer
 
 plugins = {
+    "kubernetes": KubernetesTransformer,
     "flux": FluxTransformer,
 }
 
 
-def get_transformer(name, selector, solver):
+def get_transformer(name, selector="random", solver=None):
     if name not in plugins:
         raise ValueError(f"{name} is not a valid transformer.")
     return plugins[name](selector, solver)

--- a/fractale/transformer/base.py
+++ b/fractale/transformer/base.py
@@ -21,6 +21,18 @@ class TransformerBase:
         self.selector = get_selector(selector)
         self.solver = solver
 
+    def parse(self, *args, **kwargs):
+        """
+        Parse converts the native jobspec to the standard JobSpec
+        """
+        raise NotImplementedError
+
+    def convert(self, *args, **kwargs):
+        """
+        Convert a normalized jobspec to the format here.
+        """
+        raise NotImplementedError
+
     def render(self, matches, jobspec):
         """
         Run the transformer:

--- a/fractale/transformer/common.py
+++ b/fractale/transformer/common.py
@@ -1,0 +1,51 @@
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+# Requires Python 3.8+ for dataclass
+
+
+@dataclass
+class JobSpec:
+    """
+    A scheduler-agnostic data structure for defining a computational job.
+    Version 2: Now includes accounting, priority, environment, and more constraints.
+    """
+
+    # Job Identity & Accounting
+    job_name: Optional[str] = None
+    account: Optional[str] = None
+
+    # What to Run
+    executable: Optional[str] = None
+    arguments: List[str] = field(default_factory=list)
+    container_image: Optional[str] = None
+    working_directory: Optional[str] = None
+
+    # Custom attributes or options
+    attrs: Optional[dict] = field(default_factory=dict)
+    options: Optional[dict] = field(default_factory=dict)
+
+    # Resource Requests ---
+    num_tasks: int = 1
+    num_nodes: int = 1
+    cpus_per_task: int = 1
+    mem_per_task: Optional[str] = None
+    gpus_per_task: int = 0
+
+    # Scheduling and Constraints
+    wall_time: Optional[str] = None
+    queue: Optional[str] = None
+    priority: Optional[int] = None
+    exclusive_access: bool = False
+    constraints: List[str] = field(default_factory=list)
+    begin_time: Optional[str] = None
+
+    # Environment and I/O
+    environment: Dict[str, str] = field(default_factory=dict)
+    input_file: Optional[str] = None
+    output_file: Optional[str] = None
+    error_file: Optional[str] = None
+
+    # Dependencies
+    depends_on: Optional[Union[str, List[str]]] = None

--- a/fractale/transformer/flux/__init__.py
+++ b/fractale/transformer/flux/__init__.py
@@ -1,1 +1,3 @@
 from .workload import FluxWorkload as Transformer
+
+assert Transformer

--- a/fractale/transformer/flux/validate.py
+++ b/fractale/transformer/flux/validate.py
@@ -1,0 +1,221 @@
+import re
+from io import StringIO
+
+from flux.cli.batch import BatchCmd
+from flux.job.directives import DirectiveParser
+
+import fractale.utils as utils
+from fractale.transformer.common import JobSpec
+
+
+class Validator(BatchCmd):
+    """
+    The validator validates a Flux batch script, and also
+    parses arguments into the standard format.
+    """
+
+    def derive_failure_reason(self, message):
+        """
+        Why did the directive parsing fail?
+        """
+        line = None
+        if "line" in message:
+            line = int(message.split("line", 1)[-1].split(":", 1)[0])
+
+        # E.g., # # Flux
+        if "sentinel changed" in message:
+            return "sentinel changed", line
+
+        # Directive after top of script
+        if "orphan 'flux:'" in message.lower():
+            return "orphan flux", line
+
+        if "unknown directive" in message.lower():
+            return "unknown directive", line
+
+        # Always investigate edge cases!
+        print("Unseen issue with parsing directive, investigate:")
+        print(message)
+        import IPython
+
+        IPython.embed()
+
+    def get_directive_parser(self, content, changes=None):
+        """
+        Read batch script into string, and get directive parser
+
+        If failure is due to a line that can be removed, do it.
+        """
+        if changes is None:
+            changes = []
+        string_io = StringIO(content)
+        try:
+            batchscript = DirectiveParser(string_io)
+        except Exception as e:
+            string_io.close()
+            reason, line = self.derive_failure_reason(" ".join(e.args))
+            if line is not None:
+                lines = content.split("\n")
+                deleted_line = lines[line - 1]
+                changes.append({"line": deleted_line, "reason": reason})
+                del lines[line - 1]
+                return self.get_directive_parser("\n".join(lines), changes)
+            else:
+                print("The error message did not return a line, take a look why.")
+                import IPython
+
+                IPython.embed()
+        string_io.close()
+        return batchscript, changes
+
+    def parse(self, filename):
+        """
+        Validate and parse, yielding back arguments.
+        """
+        content = utils.read_file(filename)
+
+        # Changes are removed lines to get it to read
+        batchscript, changes = self.get_directive_parser(content)
+        if changes:
+            changes = "\n".join(changes)
+            raise ValueError(f"Jobspec is invalid, required changes: {changes}")
+
+        # Assume the script is not hashbang, command or directive
+        script = [x for x in batchscript.script.split("\n") if not x.startswith("#") and x.strip()]
+
+        # We will populate the common JobSpec
+        js = JobSpec(arguments=script)
+
+        # Not parsed yet in flux:
+        #   1. input_file (Not sure what this is)
+        #   2. I don't think flux has memory per slot
+        #   3. I know flux has constraints, add parsed here
+        for item in batchscript.directives:
+            try:
+                # Validation, then mapping to standard
+                if item.action == "SETARGS":
+                    # This should only be one value, but don't assume
+                    for key, value in self.parse_argument_delta(item.args):
+                        js = self.update_jobspec(js, key, value)
+
+            except Exception:
+                name = " ".join(item.args)
+                raise ValueError(f"validation failed at {name} line {item.lineno}")
+        return js
+
+    def update_jobspec(self, js, key, value):
+        """
+        Direct mapping of a key from parsed Flux command line into standard
+        """
+        if key == "nodes":
+            js.num_nodes = value
+
+        # These need additional parsing, and can allow customization
+        elif key == "setattr":
+            for v in value:
+                key, v = v.split("=", 1)
+                if key == "container_image":
+                    js.container_image = v
+                else:
+                    js.attrs[key] = v
+        elif key == "setopt":
+            for v in value:
+                key, v = v.split("=", 1)
+                js.options[key] = v
+
+        elif key == "cwd":
+            js.working_directory = value
+        elif key == "nslots":
+            js.num_tasks = value
+        elif key == "cores_per_task":
+            js.cores_per_task = value
+        elif key == "gpus_per_task":
+            js.gpus_per_slot = value
+        elif key == "priority":
+            js.priority = value
+        elif key == "executable":
+            js.executable = value
+        elif key == "arguments":
+            js.arguments += value
+        elif key == "output":
+            js.output_file = value
+        elif key == "error":
+            js.error_file = value
+        elif key == "exclusive":
+            js.exclusive_access = value
+        elif key == "job_name":
+            js.job_name = value
+        elif key == "env":
+            js.env = value
+        elif key == "queue":
+            js.queue = value
+        elif key == "time_limit":
+            js.wall_time = parse_time_to_seconds(value)
+        elif key == "bank":
+            js.account = value
+        elif key == "dependency":
+            if not js.depends_on:
+                js.depends_on = []
+            js.depends_on += value
+        else:
+            print(f"Warning: not handled: {key}={value}")
+        return js
+
+    def parse_argument_delta(self, args):
+        """
+        Get a single parsed arg by looking at the parser delta.
+        """
+        defaults = self.parser.parse_args([])
+        updated = self.parser.parse_args(args)
+
+        # Find what's different - this will only be one value
+        for key, value in vars(updated).items():
+            if value != getattr(defaults, key):
+                yield key, value
+
+
+def parse_time_to_seconds(time_str):
+    """
+    Parses a time string like "1h30m", "1d", "50m", "3600s" into seconds.
+    """
+    if not time_str:
+        return None
+
+    total_seconds = 0
+    # Regex to find numbers and their units (d, h, m, s)
+    pattern = re.compile(r"(\d+)([dhms])")
+    matches = pattern.findall(time_str.lower())
+
+    if not matches and time_str.isdigit():
+        return int(time_str)
+
+    for value, unit in matches:
+        value = int(value)
+        if unit == "d":
+            total_seconds += value * 86400
+        elif unit == "h":
+            total_seconds += value * 3600
+        elif unit == "m":
+            total_seconds += value * 60
+        elif unit == "s":
+            total_seconds += value
+
+    return total_seconds if total_seconds > 0 else None
+
+
+def map_numeric_priority_to_class_name(priority):
+    """
+    Maps a numerical priority value to a pre-defined Kubernetes PriorityClass name.
+    Flux has a default priority of 16. I haven't looked at others yet.
+    """
+    if priority is None:
+        return "normal"
+
+    if priority <= 15:
+        return "low"
+    elif priority == 16:
+        return "normal"
+    elif 17 <= priority <= 99:
+        return "high"
+    else:
+        return "urgent"

--- a/fractale/transformer/flux/workload.py
+++ b/fractale/transformer/flux/workload.py
@@ -4,6 +4,7 @@ import json
 from fractale.logger import LogColors
 from fractale.logger.generate import JobNamer
 from fractale.transformer.base import TransformerBase
+from fractale.transformer.flux.validate import Validator
 
 
 class FluxWorkload(TransformerBase):
@@ -13,6 +14,16 @@ class FluxWorkload(TransformerBase):
     parsing the subsystems in a sort of manual way. This a filler,
     and assuming that we will have an LLM that can replace this.
     """
+
+    def parse(self, jobspec):
+        """
+        Parse an (expected) Flux jobspec. Right now we assume it is from
+        the user, so it is a Flux batch script.
+        """
+        validator = Validator("batch")
+
+        # This is a parsed (normalized) JobSpec
+        return validator.parse(jobspec)
 
     def run(self, matches, jobspec):
         """

--- a/fractale/transformer/kubernetes/__init__.py
+++ b/fractale/transformer/kubernetes/__init__.py
@@ -1,0 +1,3 @@
+from .transform import KubernetesTransformer as Transformer
+
+assert Transformer

--- a/fractale/transformer/kubernetes/transform.py
+++ b/fractale/transformer/kubernetes/transform.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import re
+import sys
+
+import yaml
+
+from fractale.logger.generate import JobNamer
+from fractale.transformer.base import TransformerBase
+
+# Assume GPUs are NVIDIA
+gpu_resource_name = "nvidia.com/gpu"
+
+
+def normalize_cpu_request(cpus: int) -> str:
+    """
+    Convert an integer number of CPUs to a Kubernetes CPU string.
+    """
+    # Kubernetes can use millicores, e.g., 1 -> "1000m", 0.5 -> "500m"
+    # We will stick to whole numbers, but this is where you'd convert.
+    return str(cpus)
+
+
+def normalize_memory_request(mem_str):
+    """
+    Convert memory units like 'G' and 'M' to Kubernetes 'Gi' and 'Mi'.
+    """
+    if not mem_str:
+        return None
+    mem_str = mem_str.upper()
+    if mem_str.endswith("G"):
+        return mem_str.replace("G", "Gi")
+    if mem_str.endswith("M"):
+        return mem_str.replace("M", "Mi")
+
+    # Assume other formats (like Gi, Mi, K, Ki) are already correct
+    return mem_str
+
+
+def get_resources(spec):
+    """
+    Get Kubernetes resources from standard jobspec
+    """
+    # Resources (CPU, Memory, GPU)
+    resources = {"requests": {}, "limits": {}}
+
+    # We usually map tasks to kubernetes cores
+    if spec.num_tasks > 1:
+        cpu_request = normalize_cpu_request(spec.num_tasks)
+        resources["requests"]["cpu"] = cpu_request
+        resources["limits"]["cpu"] = cpu_request
+
+    elif spec.cpus_per_task > 0:
+        cpu_request = normalize_cpu_request(spec.cpus_per_task)
+        resources["requests"]["cpu"] = cpu_request
+        resources["limits"]["cpu"] = cpu_request
+
+    if spec.mem_per_task:
+        mem_request = normalize_memory_request(spec.mem_per_task)
+        resources["requests"]["memory"] = mem_request
+        resources["limits"]["memory"] = mem_request
+    if spec.gpus_per_task > 0:
+        resources["limits"][gpu_resource_name] = str(spec.gpus_per_task)
+    return resources
+
+
+class KubernetesTransformer(TransformerBase):
+    """
+    A Flux Transformer is a very manual way to transform a subsystem into
+    a batch script. I am not even using jinja templates, I'm just
+    parsing the subsystems in a sort of manual way. This a filler,
+    and assuming that we will have an LLM that can replace this.
+    """
+
+    def convert(self, spec):
+        """
+        Convert a normalized jobspec to the format here.
+        """
+        # If we don't have a job name, generate one
+        # Also sanitize for Kubernetes (DNS-1123 subdomain name)
+        job_name = spec.job_name or JobNamer().generate()
+        job_name = re.sub(r"[^a-z0-9-]", "-", job_name.lower()).strip("-")
+
+        # This gets passed from flux attribute, --setattr=container_image=<value>
+        if not spec.container_image:
+            raise ValueError("Conversion to Kubernetes requires a container image.")
+
+        # Parse the application container first.
+        command = spec.executable if spec.executable else ["/bin/bash", "-c"]
+        container = {
+            "name": job_name,
+            "image": spec.container_image,
+            "command": command,
+            "args": spec.arguments or None,
+        }
+
+        resources = get_resources(spec)
+        if resources["requests"] or resources["limits"]:
+            container["resources"] = resources
+        if spec.working_directory:
+            container["workingDir"] = spec.working_directory
+        if spec.environment:
+            container["env"] = [{"name": k, "value": v} for k, v in spec.environment.items()]
+
+        pod_spec = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {"name": job_name},
+            "spec": {
+                "template": {"spec": {"containers": [container], "restartPolicy": "Never"}},
+                "backoffLimit": 0,
+            },
+        }
+
+        if spec.priority:
+            pod_spec["priorityClassName"] = str(spec.priority)
+
+        # If >1 node, set affinity to spread across
+        if spec.num_nodes > 1:
+            pod_spec.setdefault("affinity", {})
+            pod_spec["affinity"]["podAntiAffinity"] = {
+                "requiredDuringSchedulingIgnoredDuringExecution": [
+                    {
+                        "labelSelector": {
+                            "matchExpressions": [
+                                {"key": "job-name", "operator": "In", "values": [spec.job_name]}
+                            ]
+                        },
+                        "topologyKey": "kubernetes.io/hostname",
+                    }
+                ]
+            }
+
+        # This controls the Job controller itself (parallelism, deadline, etc.)
+        job_spec = {
+            "parallelism": spec.num_nodes,
+            "completions": spec.num_nodes,
+            "backoffLimit": 4,  # A sensible default
+            "template": {"metadata": {"labels": {"job-name": spec.job_name}}, "spec": pod_spec},
+        }
+
+        # This is already in seconds
+        if spec.wall_time:
+            job_spec["activeDeadlineSeconds"] = spec.wall_time
+
+        job = {
+            "apiVersion": "batch/v1",
+            "kind": "Job",
+            "metadata": {
+                "name": spec.job_name,
+            },
+            "spec": job_spec,
+        }
+
+        # Add extra attributes that aren't relevant as labels
+        if spec.account:
+            job["metadata"].setdefault("labels", {})
+            job["metadata"]["labels"]["account"] = spec.account
+        return job

--- a/fractale/version.py
+++ b/fractale/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.0.0"
+__version__ = "0.0.1"
 AUTHOR = "Vanessa Sochat"
 AUTHOR_EMAIL = "vsoch@users.noreply.github.com"
 NAME = "fractale"


### PR DESCRIPTION
We are using LLMs from a research perspective, but it is relatively straight forward to translate between job specs by doing a careful mapping. Arguably, there are many different options for any particular manager, but users only use a subset and this is not hard to do, and gives us (I think) maybe higher accuracy. The strategy here is to map each to a standard definition, and then each transformer knows how to convert the standard to their spec of choice. For K8s this will get more complex when we want multi- node and want to choose between flux-operator or trainer, but this should be a good starting case - a simple job. Using this setup we can test parsing a lot of jobspecs and understanding 1. the breakdown of params - what percentage of jobspecs use each one, and thus which are most important to include. 2. what needs mapping . For example, for flux to k8s, the main translations are times to seconds, and then a priority number to a string level. Arguably, there are always going to be some attributes that are lost. E.g., kubernetes has no sense of cpu-affinity per task, so for now I am being verbose in logging those and adding as labels.