### PR TITLE
Add support to validate canonical jobspec and walk resources

### DIFF
--- a/docker/flux-validator/Dockerfile
+++ b/docker/flux-validator/Dockerfile
@@ -5,4 +5,4 @@ LABEL maintainer="Vanessasaurus <@vsoch>"
 RUN sudo apt-get update && sudo apt-get install -y less python3-pip && python3 -m pip install IPython
 COPY ./ /code
 RUN cd /code && sudo python3 -m pip install -e .
-ENTRYPOINT ["flux", "start", "python3", "/code/docker/flux-validator/validate.py", "validate"]
+ENTRYPOINT ["flux", "start", "-Slog-stderr-level=0", "python3", "/code/docker/flux-validator/validate.py"]

--- a/docker/flux-validator/README.md
+++ b/docker/flux-validator/README.md
@@ -15,14 +15,34 @@ To run against test cases:
 #### Valid
 
 ```bash
-$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator /data/docker/flux-validator/batch.sh
+$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator validate /data/docker/flux-validator/batch.sh
 $ echo $?
+```
+
+##### Validate canonical jobspec in YAML or JSON format
+```bash
+$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator validate /data/docker/flux-validator/valid-canonical.yaml
+$ echo $?
+```
+
+##### Validate counts
+```bash
+$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator count /data/docker/flux-validator/valid-canonical.yaml
+The jobspec is valid! Here are the total resource counts per type requested by the provided jobspec:
+Type: node, count: 1
+Type: memory, count: 256
+Type: socket, count: 2
+Type: gpu, count: 8
+Type: slot, count: 4
+Type: L3cache, count: 4
+Type: core, count: 16
+Type: pu, count: 16
 ```
 
 #### Invalid
 
 ```bash
-$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator /data/docker/flux-validator/batch-invalid.sh
+$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator validate /data/docker/flux-validator/batch-invalid.sh
 usage: batch [OPTIONS...] COMMAND [ARGS...]
 batch: error: unrecognized arguments: --noodles=2
 Flux Batch Validation Failed:
@@ -39,5 +59,45 @@ hostname
 Validation failed at directives:
 #FLUX directives need to be FLUX:
 --noodles=2: 2
-Sep 09 06:48:51.615419 UTC 2025 broker.err[0]: rc2.0: python3 /code/docker/flux-validator/validate.py validate /data/docker/flux-validator/batch-invalid.sh Exited (rc=1) 0.1s
+```
+
+##### Invalid canonical jobspec
+```bash
+$ docker run -it -v $(pwd):/data ghcr.io/compspec/fractale:flux-validator validate /data/docker/flux-validator/invalid-canonical-slot.yaml
+Flux Batch Validation Failed:
+version: 9999
+resources:
+    - type: node
+      count: 1
+      with:
+        - type: memory
+          count: 256
+        - type: socket
+          count: 2
+          with:
+            - type: gpu
+              count: 4
+            - type: slot
+              count: 2
+              with:
+                - type: L3cache
+                  count: 1
+                  with:
+                    - type: core
+                      count: 4
+                      with:
+                        - type: pu
+                          count: 1
+
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1
+
+slots must have labels
 ```

--- a/docker/flux-validator/invalid-canonical-slot.yaml
+++ b/docker/flux-validator/invalid-canonical-slot.yaml
@@ -1,0 +1,33 @@
+version: 9999
+resources:
+    - type: node
+      count: 1
+      with:
+        - type: memory
+          count: 256
+        - type: socket
+          count: 2
+          with:
+            - type: gpu
+              count: 4
+            - type: slot
+              count: 2
+              with:
+                - type: L3cache
+                  count: 1
+                  with:
+                    - type: core
+                      count: 4
+                      with:
+                        - type: pu
+                          count: 1
+
+# a comment
+attributes:
+  system:
+    duration: 3600
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/docker/flux-validator/valid-canonical.yaml
+++ b/docker/flux-validator/valid-canonical.yaml
@@ -1,0 +1,34 @@
+version: 9999
+resources:
+  - type: node
+    count: 1
+    with:
+      - type: memory
+        count: 256
+      - type: socket
+        count: 2
+        with:
+          - type: gpu
+            count: 4
+          - type: slot
+            count: 2
+            label: default
+            with:
+              - type: L3cache
+                count: 1
+                with:
+                  - type: core
+                    count: 4
+                    with:
+                      - type: pu
+                        count: 1
+
+# a comment
+attributes:
+  system:
+    duration: "3600"
+tasks:
+  - command: [ "app" ]
+    slot: default
+    count:
+      per_slot: 1

--- a/docker/flux-validator/valid-v1.json
+++ b/docker/flux-validator/valid-v1.json
@@ -1,0 +1,53 @@
+{
+  "resources": [
+    {
+      "type": "slot",
+      "count": 1,
+      "label": "default",
+      "with": [
+        {
+          "type": "node",
+          "count": 1,
+          "exclusive": true,
+          "with": [
+            {
+              "type": "slot",
+              "count": 1,
+              "with": [
+                {
+                  "type": "core",
+                  "count": 1
+                }
+              ],
+              "label": "task"
+            }
+          ]
+        },
+        {
+          "type": "ssd",
+          "count": 20480,
+          "exclusive": true
+        }
+      ]
+    }
+  ],
+  "tasks": [
+    {
+      "command": [
+        "hostname"
+      ],
+      "slot": "task",
+      "count": {
+        "per_slot": 1
+      }
+    }
+  ],
+  "attributes": {
+    "system": {
+      "duration": 0,
+      "environment": {},
+      "shell": {}
+    }
+  },
+  "version": 1
+}


### PR DESCRIPTION
This PR adds capability to validate Flux canonical jobspec via the Flux `Jobspec`member function `validate_jobspec()`. It also adds support for walking a canonical jobspec tree and counting and outputting the summed resource counts by type. This output can be used in an agentic framework to correct a generated canonical jobspec. 